### PR TITLE
Fixed the command continuation characters that were missing and skipp…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV SPARK_HOME /usr/local/src/spark-$SPARK_VERSION
 RUN \
     mkdir -p $SPARK_HOME &&\
     curl -s http://d3kbcqa49mib13.cloudfront.net/spark-$SPARK_VERSION.tgz | tar -xz -C $SPARK_HOME --strip-components=1 &&\
-    cd $SPARK_HOME \
+    cd $SPARK_HOME &&\
     build/mvn -DskipTests clean package
 
 ENV PYTHONPATH $SPARK_HOME/python/:$PYTHONPATH
@@ -30,7 +30,7 @@ RUN apt-get install -y build-essential \
     python-zmq
 
 RUN pip install py4j \
-    ipython[notebook] \
+    ipython[notebook]==3.2 \
     jsonschema \
     jinja2 \
     terminado \


### PR DESCRIPTION
…ing the build process

Switched ipython to be v3.2 as 4.0 no longer appears to support profiles correctly

Re-done to contain only the commit I meant to do the PR for.

I also noticed a problem with the docker-compose.yml where it would give me a Go marshaling error trying to run docker-compose up -d. The issue appeared to be with the working_dir and having a colon in the value.
